### PR TITLE
For Yenten-5.0.0(yespowerR16)

### DIFF
--- a/lib/jobManager.js
+++ b/lib/jobManager.js
@@ -112,6 +112,17 @@ var JobManager = module.exports = function JobManager(options) {
                 return function (d) {
                     return util.reverseBuffer(util.sha256d(d));
                 };
+            case 'yespowerR16':
+                if (Date.now() / 1000 > 1675036800) {
+                    return function (d) {
+                        return util.reverseBuffer(util.sha256d(d));
+                    };
+                }
+                else {
+                    return function () {
+                        return util.reverseBuffer(hashDigest.apply(this, arguments));
+                    };
+                }
             default:
                 return function () {
                     return util.reverseBuffer(hashDigest.apply(this, arguments));


### PR DESCRIPTION
/* Japanese follows English. (英語の後に日本語が続きます。) */

Yenten-5.0.0 has been released.
In Yenten-5.0.0, the mining (PoW) algorithm is still yespowerR16, but the hashing of block headers will be changed to SHA-256 instead of yespowerR16 after Jan. 30 00:00 (UTC). The relevant part of the source is here.
https://github.com/yentencoin/yenten/blob/yenten-5.0.0/src/primitives/block.cpp#L19-L30
Elicoin and other coins that use yescryptR16 have been doing so for some time. Mining software such as cpuminer-opt does not need to be changed, but the mining pool needs to be adapted.

As shown in your nomp repository, for yescryptR16:
https://github.com/ROZ-MOFUMOFU-ME/node-stratum-pool/blob/main/lib/jobManager.js#L111-L114
as well as yespowerR16 needs to be similarly configured after 30 Jan 2023 00:00 (UTC).
I've considered switching the process conditional on UNIX time in this pull request, but nomp only calls jobManger.js on startup and does not seem to be able to switch hash functions dynamically. The mining itself does not stop after 30 Jan 2023 00:00 (UTC) with my switching settings, but even if a block is found, it is caught by the decision here↓ and is not counted as mined.
https://github.com/ROZ-MOFUMOFU-ME/zny-nomp/blob/main/libs/poolWorker.js#L178-L179
Anyway, it seems that the pool administrator needs to stop the YTN pool once before 30 Jan 2023 00:00 (UTC), update the necessary settings and restart it.

After January 30, I would appreciate it if you could simply add the same process as yescriptR16.
Thank you in advance.


Yenten-5.0.0がリリースされました。
Yenten-5.0.0ではマイニング(PoW)のアルゴリズムはyespowerR16のままですが、1月30日 00:00 (UTC) 以降、ブロックのヘッダーのハッシュ処理がyespowerR16ではなくSHA-256に変更されます。ソースの該当箇所はこちらになります。
https://github.com/yentencoin/yenten/blob/yenten-5.0.0/src/primitives/block.cpp#L19-L30
Elicoinなど yescryptR16 なコインでは以前からそのような処理をしているようです。cpuminer-optなどマイニングソフトは変更する必要がありませんが、マイニングプール側では対応が必要になります。

ROZさんのnompレポジトリで示すと、yescryptR16向けに
https://github.com/ROZ-MOFUMOFU-ME/node-stratum-pool/blob/main/lib/jobManager.js#L111-L114
のように設定されていますが、yespowerR16も2023年1月30日 00:00 (UTC)以降は同様の設定が必要です。
今回のプルリクエストではUNIX時間を条件として処理を切り替えることを考えてみましたが、nompは起動時にjobManger.jsを呼ぶだけで、動的にハッシュ関数を切り替えることは出来ないようです。上の設定で2023年1月30日 00:00 (UTC)をまたいでもマイニング自体は止まりませんが、ブロックを発見してもここ↓の判定に引っ掛かり、掘り当てたものとしてカウントされませんでした。
https://github.com/ROZ-MOFUMOFU-ME/zny-nomp/blob/main/libs/poolWorker.js#L178-L179
とにかく、2023年1月30日 00:00 (UTC)より前に一旦YTNプールを停止して、必要な設定更新してから再始動するというようなことが必要そうです。

1月30日以降であれば、単純にyescriptR16と同様の処理を加えて頂けると有難いです。
よろしくお願いいたします。
