### PR TITLE
For Yenten-5.0.0 (yespowerR16, after 2023Jan30)

### DIFF
--- a/lib/jobManager.js
+++ b/lib/jobManager.js
@@ -113,16 +113,9 @@ var JobManager = module.exports = function JobManager(options) {
                     return util.reverseBuffer(util.sha256d(d));
                 };
             case 'yespowerR16':
-                if (Date.now() / 1000 > 1675036800) {
-                    return function (d) {
-                        return util.reverseBuffer(util.sha256d(d));
-                    };
-                }
-                else {
-                    return function () {
-                        return util.reverseBuffer(hashDigest.apply(this, arguments));
-                    };
-                }
+                return function (d) {
+                    return util.reverseBuffer(util.sha256d(d));
+                };
             default:
                 return function () {
                     return util.reverseBuffer(hashDigest.apply(this, arguments));

--- a/lib/jobManager.js
+++ b/lib/jobManager.js
@@ -112,6 +112,17 @@ var JobManager = module.exports = function JobManager(options) {
                 return function (d) {
                     return util.reverseBuffer(util.sha256d(d));
                 };
+            case 'yespowerR16':
+                if (Date.now() / 1000 > 1675036800) {
+                    return function (d) {
+                        return util.reverseBuffer(util.sha256d(d));
+                    };
+                }
+                else {
+                    return function () {
+                        return util.reverseBuffer(hashDigest.apply(this, arguments));
+                    };
+                }
             default:
                 return function () {
                     return util.reverseBuffer(hashDigest.apply(this, arguments));


### PR DESCRIPTION
/* Japanese follows English. (英語の後に日本語が続きます。) */

Yenten-5.0.0 has been released.
In Yenten-5.0.0, the mining (PoW) algorithm is still yespowerR16, but the hashing of block headers has been changed to SHA-256 instead of yespowerR16 after Jan. 30 00:00 (UTC). The relevant part of the source is here.
https://github.com/yentencoin/yenten/blob/yenten-5.0.0/src/primitives/block.cpp#L19-L30
Elicoin and other coins that use yescryptR16 have been doing so for some time. Mining software such as cpuminer-opt does not need to be changed, but the mining pool needs to be adapted.

As shown in your nomp repository, for yescryptR16:
https://github.com/ROZ-MOFUMOFU-ME/node-stratum-pool/blob/main/lib/jobManager.js#L111-L114
In this pull request, I've added a similar procedure for yespowerR16.
Mining itself does not stop without the addition of this procedure, but even if a block is found, it is caught by the decision here↓ and is not counted as mined, resulting in the mining reward not being distributed to the respective worker.
https://github.com/ROZ-MOFUMOFU-ME/zny-nomp/blob/main/libs/poolWorker.js#L178-L179
Thank you in advance.


Yenten-5.0.0がリリースされました。
Yenten-5.0.0ではマイニング(PoW)のアルゴリズムはyespowerR16のままですが、1月30日 00:00 (UTC) 以降、ブロックのヘッダーのハッシュ処理がyespowerR16ではなくSHA-256に変更されています。ソースの該当箇所はこちらになります。
https://github.com/yentencoin/yenten/blob/yenten-5.0.0/src/primitives/block.cpp#L19-L30
Elicoinなど yescryptR16 なコインでは以前からそのような処理をしているようです。cpuminer-optなどマイニングソフトは変更する必要がありませんが、マイニングプール側では対応が必要になります。

ROZさんのnompレポジトリで示すと、yescryptR16向けに
https://github.com/ROZ-MOFUMOFU-ME/node-stratum-pool/blob/main/lib/jobManager.js#L111-L114
のように設定されていますが、このプルリクエストでyespowerR16に対して同様の手順を追加しました。
この手順を追加しなくてもマイニング自体は止まりませんが、ブロックを発見してもここ↓の判定に引っ掛かり、掘り当てたものとしてカウントされず、結果的にマイニングの報酬がそれぞれのワーカーに分配されません。
https://github.com/ROZ-MOFUMOFU-ME/zny-nomp/blob/main/libs/poolWorker.js#L178-L179
よろしくお願いいたします。