### PR TITLE
chore(deps): override flatted (eslint prototype-pollution alert)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
                 "prettier": "^3.8.4"
             },
             "engines": {
-                "node": ">=18",
+                "node": ">=20",
                 "npm": ">=9"
             }
         },
@@ -860,9 +860,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-            "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
             "dev": true,
             "license": "ISC"
         },

--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
         "eslint-config-prettier": "^10.1.8",
         "prettier": "^3.8.4"
     },
+    "overrides": {
+        "flatted": "^3.4.2"
+    },
     "engines": {
         "node": ">=20",
         "npm": ">=9"


### PR DESCRIPTION
Override flatted to 3.4.2 to clear the dependabot prototype-pollution alert.