### PR TITLE
ci: bump actions/checkout and setup-node to v6

### DIFF
--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -11,10 +11,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: '22.x'
 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,9 +11,9 @@ jobs:
             matrix:
                 node-version: [20.x, 22.x, 24.x]
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: ${{ matrix.node-version }}
             - name: Run build


### PR DESCRIPTION
v4 uses the deprecated Node 20 runtime; v6 runs on Node 24.