### PR TITLE
chore(deps): advance multi-hashing pin to latest main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1015,7 +1015,7 @@
         },
         "node_modules/multi-hashing": {
             "version": "1.1.1",
-            "resolved": "git+ssh://git@github.com/ROZ-MOFUMOFU-ME/node-multi-hashing.git#a48bcad42b22674f4b9e1de376c2ee1a63a8628a",
+            "resolved": "git+ssh://git@github.com/ROZ-MOFUMOFU-ME/node-multi-hashing.git#d03e9ac113be0872766b351b72a17bee7ae7c4de",
             "hasInstallScript": true,
             "dependencies": {
                 "bindings": "^1.5.0",


### PR DESCRIPTION
Update the locked multi-hashing commit to latest main (ftime fix, CircleCI modernization).