### PR TITLE
chore: release v0.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "stratum-pool",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "stratum-pool",
-            "version": "0.3.1",
+            "version": "0.3.2",
             "license": "GPL-2.0",
             "dependencies": {
                 "@exodus/bitcoinjs-lib-zcash": "^0.0.19",
@@ -1014,8 +1014,8 @@
             "license": "MIT"
         },
         "node_modules/multi-hashing": {
-            "version": "1.1.1",
-            "resolved": "git+ssh://git@github.com/ROZ-MOFUMOFU-ME/node-multi-hashing.git#d03e9ac113be0872766b351b72a17bee7ae7c4de",
+            "version": "1.1.2",
+            "resolved": "git+ssh://git@github.com/ROZ-MOFUMOFU-ME/node-multi-hashing.git#e724b1edaf05322aec3169c9c22e21c39650b3ae",
             "hasInstallScript": true,
             "dependencies": {
                 "bindings": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "stratum-pool",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "type": "module",
     "description": "High performance Stratum poolserver in Node.js",
     "keywords": [


### PR DESCRIPTION
Bump version to 0.3.2 and advance multi-hashing pin to v1.1.2.