### PR TITLE
ci: install GCC 10 on CircleCI for C++20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,13 @@ jobs:
             - node/install:
                   node-version: << parameters.node-version >>
             - run:
+                  name: Install GCC 10 (C++20 support for the multi-hashing addon)
+                  command: |
+                      sudo apt-get update
+                      sudo apt-get install -y g++-10 gcc-10
+                      sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100
+                      sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 100
+            - run:
                   name: Run build
                   command: npm install
             - run:


### PR DESCRIPTION
cimg/base ships GCC 9 which rejects -std=c++20; install g++-10 for the native multi-hashing build.