### PR TITLE
docs: add stratum DoS/TLS hardening to roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,6 +40,10 @@ depends on [node-multi-hashing](https://github.com/ROZ-MOFUMOFU-ME/node-multi-ha
   getblocktemplate → share → submitblock flow.
 - Document the extended mining.notify protocol (vipstar stateroot/utxoroot,
   qtum-style 181-byte header) for miner authors.
+- **Security hardening** — review and tune the stratum server's DoS
+  protections (IP banning, connection timeouts, invalid-share thresholds)
+  and document the TLS-port configuration; this feeds the portal's
+  security-hardening focus area.
 
 ### Long-term
 - Refactor `algoProperties` so the block-hash function and difficulty


### PR DESCRIPTION
Add stratum-server DoS/TLS hardening under mid-term, feeding the portal security focus area.