### PR TITLE
fix: build Sapling (Koto) block merkle root from full-tx hash, not txid

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,18 +14,26 @@ depends on [node-multi-hashing](https://github.com/ROZ-MOFUMOFU-ME/node-multi-ha
   vipstar (VIPSTARCOIN, 181-byte qtum-style header), sha256d, quark, x11.
 - Developer-fee coinbase output (Yenten 6.1) and the extended `mining.notify`
   params for VIPSTARCOIN (reversed stateroot/utxoroot) are implemented.
+- **Sapling block construction (Koto)**: the block merkle root is built from
+  each transaction's full-serialization hash (`sha256d`, the getblocktemplate
+  `hash`), not `txid` — shielded Sapling txs have `txid != sha256d(tx)`, so
+  using `txid` corrupted the root and the daemon rejected any block carrying a
+  shielded mempool tx with `CheckBlock(): hashMerkleRoot mismatch`. Blocks now
+  pass the daemon's merkle check; Bitcoin/segwit chains still commit `txid`.
 
 ## Known issues & limitations
 
-- **Minimal test** — `test.mjs` only imports the module and calls
-  `createPool()`; there is no per-algorithm or protocol-level coverage.
+- **Minimal test** — `test.mjs` imports the module, calls `createPool()`, and
+  asserts the per-chain merkle-leaf selection (Sapling=`hash`, Bitcoin=`txid`);
+  there is still no broader per-algorithm or protocol-level coverage.
 - Several algorithms in the README are marked "may work" / "not working" and
   are unverified against live daemons.
 - Coin-specific paths (Koto founders reward, Dash masternode/superblock
   payees, POS reward type) have no regression coverage.
 - `algoProperties.js` block-hash handling has repetitive per-algorithm
   branches that are easy to get subtly wrong (the vipstar/lyra2rev2 fixes
-  were both block-hash issues).
+  were both block-hash issues; the Koto Sapling merkle-leaf fix was a related
+  per-chain serialization issue, now guarded by a regression test).
 
 ## Roadmap
 

--- a/lib/blockTemplate.js
+++ b/lib/blockTemplate.js
@@ -29,7 +29,25 @@ const BlockTemplate = function BlockTemplate(
     }
 
     function getTransactionBuffers(txs) {
+        // Which transaction hash gets committed to the block merkle root differs
+        // by chain family:
+        //   - Zcash/Sapling chains (e.g. Koto) commit each tx's GetHash() — the
+        //     sha256d of the FULL serialization, exposed as `hash` by
+        //     getblocktemplate. For shielded txs this differs from `txid` (which
+        //     omits the binding signature / auth data), so using `txid` corrupts
+        //     the merkle root and the daemon rejects the block with
+        //     "CheckBlock(): hashMerkleRoot mismatch".
+        //   - Bitcoin/segwit chains commit `txid` (with `hash` being the witness
+        //     wtxid), so `txid` must be used there.
+        // A Sapling template is identified by the finalsaplingroothash field.
+        const saplingMerkle = rpcData.finalsaplingroothash !== undefined;
         const txHashes = txs.map(function (tx) {
+            if (saplingMerkle) {
+                if (tx.hash !== undefined) {
+                    return util.uint256BufferFromHash(tx.hash);
+                }
+                return util.sha256d(Buffer.from(tx.data, 'hex'));
+            }
             if (tx.txid !== undefined) {
                 return util.uint256BufferFromHash(tx.txid);
             }

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -300,9 +300,16 @@ const pool = function pool(options, authorizeFn) {
                         } when submitting block with ${rpcCommand} ${JSON.stringify(result.error)}`
                     );
                     return;
-                } else if (result.response === 'rejected') {
+                } else if (result.response) {
+                    // submitblock / getblocktemplate(submit) return null when the
+                    // block is accepted and a BIP22 reason string otherwise (e.g.
+                    // "rejected", "high-hash", "duplicate", "bad-txnmrklroot").
+                    // Surface the actual reason instead of silently treating any
+                    // non-"rejected" response as a successful submission.
                     emitErrorLog(
-                        `Daemon instance ${result.instance.index} rejected a supposedly valid block`
+                        `Daemon instance ${result.instance.index} rejected a supposedly valid block with ${rpcCommand}: ${JSON.stringify(
+                            result.response
+                        )}`
                     );
                     return;
                 }

--- a/test.mjs
+++ b/test.mjs
@@ -1,6 +1,67 @@
+import assert from 'node:assert';
 import * as stratumPool from './lib/index.js';
+import BlockTemplate from './lib/blockTemplate.js';
+import * as util from './lib/util.js';
 
 console.log('Successfully imported stratum-pool module');
+
+// Regression: block merkle leaves must use the right per-chain tx hash.
+// Zcash/Sapling chains (e.g. Koto) commit sha256d(full tx serialization)
+// (getblocktemplate `hash`) to the merkle root, which differs from `txid` for
+// shielded txs; Bitcoin/segwit chains commit `txid`. Picking the wrong field
+// makes the daemon reject blocks with "hashMerkleRoot mismatch".
+try {
+    const poolScript = Buffer.alloc(25, 0x11); // dummy P2PKH-sized script
+    const extraNoncePlaceholder = Buffer.from('f000000ff111111f', 'hex');
+    const data = Buffer.from('abcdef0123456789', 'hex'); // arbitrary tx body
+    const fullHashLE = util.sha256d(data); // = the daemon's GetHash() (internal/LE)
+    const fullHashBE = util.reverseBuffer(fullHashLE).toString('hex'); // gbt `hash`
+    const txid = 'aa'.repeat(32); // intentionally != fullHash (shielded-style)
+
+    const baseRpc = {
+        bits: '1e0fffff',
+        previousblockhash: '00'.repeat(32),
+        height: 100,
+        coinbasevalue: 5000000000,
+        transactions: [{ data: data.toString('hex'), hash: fullHashBE, txid }],
+    };
+
+    const sapling = new BlockTemplate(
+        '1',
+        { ...baseRpc, version: 5, finalsaplingroothash: '22'.repeat(32) },
+        poolScript,
+        extraNoncePlaceholder,
+        undefined,
+        undefined,
+        [],
+        undefined
+    );
+    assert.strictEqual(
+        sapling.merkleBranch[0],
+        fullHashLE.toString('hex'),
+        'Sapling template must build merkle leaves from sha256d(full tx data), not txid'
+    );
+
+    const bitcoinish = new BlockTemplate(
+        '1',
+        baseRpc, // no finalsaplingroothash
+        poolScript,
+        extraNoncePlaceholder,
+        undefined,
+        undefined,
+        [],
+        undefined
+    );
+    assert.strictEqual(
+        bitcoinish.merkleBranch[0],
+        util.reverseBuffer(Buffer.from(txid, 'hex')).toString('hex'),
+        'Non-Sapling template must keep building merkle leaves from txid'
+    );
+    console.log('merkle leaf selection (Sapling=hash, Bitcoin=txid) verified');
+} catch (e) {
+    console.error('Merkle leaf regression test failed:', e.message);
+    process.exit(1);
+}
 
 // Test createPool call (dummy configuration)
 try {


### PR DESCRIPTION
## What

Zcash/Sapling-derived chains (e.g. **Koto**) commit each transaction's `GetHash()` — `sha256d` of the **full** serialization, exposed as the getblocktemplate `hash` field — to the block merkle root. For **shielded** transactions this differs from `txid` (which omits the binding signature / auth data).

`getTransactionBuffers` preferred `txid`, so whenever a found block carried a shielded mempool transaction the merkle root was wrong and the daemon rejected it with `CheckBlock(): hashMerkleRoot mismatch` — **even though the PoW was valid**, so real blocks and their rewards were silently lost. Coinbase-only / transparent-only blocks happened to work because there `txid == sha256d(tx)`.

## Fix

- Select the merkle leaf per chain family: Sapling templates (identified by `finalsaplingroothash`) use `hash` / `sha256d(full tx)`; Bitcoin/segwit chains keep using `txid` (where `hash` is the witness wtxid). No change for non-Sapling coins (e.g. Monacoin segwit).
- `pool.js`: surface the actual BIP22 reject reason from `submitblock` instead of only matching the literal string `"rejected"`.
- `test.mjs`: regression test exercising the real `BlockTemplate` merkle-leaf selection (Sapling=`hash`, Bitcoin=`txid`).

Verified end-to-end by reproducing a real Koto block's `hashMerkleRoot` through the actual `merkleTree.withFirst` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)