### PR TITLE
chore: release 0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "stratum-pool",
-    "version": "0.4.0-beta.0",
+    "version": "0.4.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "stratum-pool",
-            "version": "0.4.0-beta.0",
+            "version": "0.4.0",
             "license": "GPL-2.0",
             "dependencies": {
                 "@exodus/bitcoinjs-lib-zcash": "^0.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "stratum-pool",
-    "version": "0.4.0-beta.0",
+    "version": "0.4.0",
     "type": "module",
     "description": "High performance Stratum poolserver in Node.js",
     "keywords": [


### PR DESCRIPTION
Release 0.4.0 (drops -beta.0): Koto Sapling block merkle-root fix + require(esm)-capable Node engines floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)